### PR TITLE
Fix Bug -> "ANSICallbacksSuite.sprint" is called as "ANSICallbacksSuite.pow"

### DIFF
--- a/src/headers/suites.hh
+++ b/src/headers/suites.hh
@@ -147,29 +147,27 @@ typedef struct PF_WorldTransformSuite1 {
 } PF_WorldTransformSuite1;
 
 typedef struct PF_ANSICallbacksSuite {
-	double (*sin)(double);
-	double (*cos)(double);
-	double (*tan)(double);
-
-	double (*asin)(double);
-	double (*acos)(double);
 	double (*atan)(double);
-	double (*atan2)(double y, double x);
-
-	double (*log)(double);
-	double (*log10)(double);
-
+	double (*atan2)(double, double);
 	double (*ceil)(double);
+	double (*cos)(double);
 	double (*exp)(double);
 	double (*fabs)(double);
 	double (*floor)(double);
-	double (*fmod)(double x, double y);
-	double (*hypot)(double x, double y);
-	// double (*pow)(double x, double y);
-	// double (*sqrt)(double);
+	double (*fmod)(double, double);
+	double (*hypot)(double, double);
+	double (*log)(double);
+	double (*log10)(double);
+	double (*pow)(double, double);
+	double (*sin)(double);
+	double (*sqrt)(double);
+	double (*tan)(double);
 
 	int (*sprintf)(char *, const char *, ...);
 	char * (*strcpy)(char *, const char *);
+
+	double (*asin)(double);
+	double (*acos)(double);
 } PF_ANSICallbacksSuite;
 
 typedef struct PF_EffectUISuite1 {

--- a/src/headers/suites.hh
+++ b/src/headers/suites.hh
@@ -165,8 +165,8 @@ typedef struct PF_ANSICallbacksSuite {
 	double (*floor)(double);
 	double (*fmod)(double x, double y);
 	double (*hypot)(double x, double y);
-	double (*pow)(double x, double y);
-	double (*sqrt)(double);
+	// double (*pow)(double x, double y);
+	// double (*sqrt)(double);
 
 	int (*sprintf)(char *, const char *, ...);
 	char * (*strcpy)(char *, const char *);

--- a/src/plugin_instance.cc
+++ b/src/plugin_instance.cc
@@ -151,15 +151,15 @@ int PluginInstance::Execute (PF_Cmd cmd, PF_InData *in_data, PF_OutData *outData
 				return 0;
 			};
 
-			ansi->pow = [](double x, double y) -> double {
-				std::cout << "pow: " << x << std::endl;
-				return 0;
-			};
+			// ansi->pow = [](double x, double y) -> double {
+			// 	std::cout << "pow: " << x << std::endl;
+			// 	return 0;
+			// };
 
-			ansi->sqrt = [](double x) -> double {
-				std::cout << "sqrt: " << x << std::endl;
-				return 0;
-			};
+			// ansi->sqrt = [](double x) -> double {
+			// 	std::cout << "sqrt: " << x << std::endl;
+			// 	return 0;
+			// };
 
 			ansi->sprintf = [](char *buffer, const char *format, ...) -> int {
 				va_list args;

--- a/src/plugin_instance.cc
+++ b/src/plugin_instance.cc
@@ -151,15 +151,15 @@ int PluginInstance::Execute (PF_Cmd cmd, PF_InData *in_data, PF_OutData *outData
 				return 0;
 			};
 
-			// ansi->pow = [](double x, double y) -> double {
-			// 	std::cout << "pow: " << x << std::endl;
-			// 	return 0;
-			// };
+			ansi->pow = [](double x, double y) -> double {
+				std::cout << "pow: " << x << std::endl;
+				return 0;
+			};
 
-			// ansi->sqrt = [](double x) -> double {
-			// 	std::cout << "sqrt: " << x << std::endl;
-			// 	return 0;
-			// };
+			ansi->sqrt = [](double x) -> double {
+				std::cout << "sqrt: " << x << std::endl;
+				return 0;
+			};
 
 			ansi->sprintf = [](char *buffer, const char *format, ...) -> int {
 				va_list args;


### PR DESCRIPTION
## Description

I found a regularity in this bug.

- When plugin calls ```ANSICallbacksSuite.sprintf()```, host is called as ```ANSICallbacksSuite.pow()```
- When plugin calls ```ANSICallbacksSuite.pow()```, host is called as ```ANSICallbacksSuite.fabs()```

## Changes

Rearrange function definitions of ```ANSICallbacksSuite``` to match order to AE SDK's one.

### ↓ AE SDK's function definitions ↓

```cpp
typedef struct PF_ANSICallbacksSuite1 {
	A_FpLong	(*atan)(A_FpLong);
	A_FpLong	(*atan2)(A_FpLong y, A_FpLong x);
	A_FpLong	(*ceil)(A_FpLong);
	A_FpLong	(*cos)(A_FpLong);
	A_FpLong	(*exp)(A_FpLong);
	A_FpLong	(*fabs)(A_FpLong);
	A_FpLong	(*floor)(A_FpLong);
	A_FpLong	(*fmod)(A_FpLong x, A_FpLong y);
	A_FpLong	(*hypot)(A_FpLong x, A_FpLong y);
	A_FpLong	(*log)(A_FpLong);
	A_FpLong	(*log10)(A_FpLong);
	A_FpLong	(*pow)(A_FpLong x, A_FpLong y);
	A_FpLong	(*sin)(A_FpLong);
	A_FpLong	(*sqrt)(A_FpLong);
	A_FpLong	(*tan)(A_FpLong);

	int		(*sprintf)(A_char *, const A_char *, ...);
	A_char *	(*strcpy)(A_char *, const A_char *);

	A_FpLong (*asin)(A_FpLong);
	A_FpLong (*acos)(A_FpLong);
} PF_ANSICallbacksSuite1;
```

## Result

All functions work correctly!!!

Fixes #3 